### PR TITLE
Add fallback defaults for pointsCount, targetsCount, and opacity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ trap "kill $SERVER_PID 2>/dev/null || true" EXIT
   SERVER_PID=$!
   trap "kill $SERVER_PID 2>/dev/null || true" EXIT
   ```
-Do not reuse that shell after you complete your task. The trap command will clean things up when you quit the shell.
+It will be immediately available. Do not reuse that shell after you complete your task. The trap command will clean things up when you quit the shell.
 - then use the Playwright MCP server to go to this URL to try your functionality:
 http://127.0.0.1:8910/web/chaos-game-3d.html
 

--- a/web/static/chaos-game-3d.js
+++ b/web/static/chaos-game-3d.js
@@ -385,6 +385,24 @@ function generatePoints(debugMode, consumePoints) {
     }
   }
 
+  // Fallback defaults for user-settable values
+  const DEFAULT_TARGETS_COUNT = 4;
+  const DEFAULT_POINTS_COUNT = 100000;
+  const DEFAULT_OPACITY = 1;
+
+  if (scope.targetsCount === undefined) {
+    console.info('targetsCount not set by user code, using default:', DEFAULT_TARGETS_COUNT);
+    scope.targetsCount = DEFAULT_TARGETS_COUNT;
+  }
+  if (scope.pointsCount === undefined) {
+    console.info('pointsCount not set by user code, using default:', DEFAULT_POINTS_COUNT);
+    scope.pointsCount = DEFAULT_POINTS_COUNT;
+  }
+  if (scope.opacity === undefined) {
+    console.info('opacity not set by user code, using default:', DEFAULT_OPACITY);
+    scope.opacity = DEFAULT_OPACITY;
+  }
+
   // Update scope with current target points after initialization MathJS executes
   if (scope['targetPoints'] === undefined) {
     // default targets: spread (approximately, typically) evenly the desired number of targets around on the 3D unit sphere (genus 0), then scale
@@ -394,7 +412,6 @@ function generatePoints(debugMode, consumePoints) {
   createTargetMeshes();
   scope['targetPointsLength'] = targets.size()[0];
 
-  // TODO: if these aren't set, perhaps go with default and issue a warning into the errorMessage div.
   const steps = scope.pointsCount;
   const defaultAlphaValue = scope.opacity;
 


### PR DESCRIPTION
When user's MathJS code doesn't set these values, the system now falls back to sensible defaults (100000, 4, and 1 respectively) and logs an info message to the console.

Fixes #132

--
Committed by Amp